### PR TITLE
Add py123d dataparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ To add a dataset, create `nerfstudio/data/dataparsers/mydataset.py` containing o
 | 🚗 [Waymo v2](https://waymo.com/open/)         | 5 cameras | 64-beam lidar
 | 🚗 [py123d](https://github.com/kesai-labs/py123d) | user-specified (pinhole) | user-specified |
 
-A brief introduction about Waymo dataparser for NeuRAD can be found in [waymo_dataparser.md](./nerfstudio/data//dataparsers/waymo_dataparser.md).
+A brief introduction about Waymo dataparser for NeuRAD can be found in [waymo_dataparser.md](./nerfstudio/data/dataparsers/waymo_dataparser.md).
 For training on [py123d](https://github.com/kesai-labs/py123d) Arrow logs, see [docs/py123d-data.md](./docs/py123d-data.md) and the example config [docs/examples/py123d_example.yaml](./docs/examples/py123d_example.yaml).
 
 ## Adding Methods

--- a/README.md
+++ b/README.md
@@ -260,8 +260,10 @@ To add a dataset, create `nerfstudio/data/dataparsers/mydataset.py` containing o
 | 🚗 [PandaSet](https://pandaset.org/) ([huggingface download](https://huggingface.co/datasets/georghess/pandaset))         | 6 cameras | 64-beam lidar                                  |
 | 🚗 [KITTIMOT](https://www.cvlibs.net/datasets/kitti/eval_tracking.php) ([Timestamps](https://www.cvlibs.net/datasets/kitti/raw_data.php)) | 2 stereo cameras | 64-beam lidar
 | 🚗 [Waymo v2](https://waymo.com/open/)         | 5 cameras | 64-beam lidar
+| 🚗 [py123d](https://github.com/kesai-labs/py123d) | user-specified (pinhole) | user-specified |
 
-A brief introduction about Waymo dataparser for NeuRAD can be found in [waymo_dataparser.md](./nerfstudio/data//dataparsers/waymo_dataparser.md)
+A brief introduction about Waymo dataparser for NeuRAD can be found in [waymo_dataparser.md](./nerfstudio/data//dataparsers/waymo_dataparser.md).
+For training on [py123d](https://github.com/kesai-labs/py123d) Arrow logs, see [docs/py123d-data.md](./docs/py123d-data.md) and the example config [docs/examples/py123d_example.yaml](./docs/examples/py123d_example.yaml).
 
 ## Adding Methods
 

--- a/docs/examples/py123d_example.yaml
+++ b/docs/examples/py123d_example.yaml
@@ -1,0 +1,79 @@
+# Example py123d-data settings for NeuRAD / SplatAD.
+#
+# Neurad passes these as CLI flags under the `py123d-data` subcommand
+# (see docs/py123d-data.md). This file is a readable reference — copy values
+# into your train command or adapt them for your export.
+#
+# Expected on-disk layout for the settings below:
+#
+#   data/py123d/
+#     logs/
+#       train/
+#         my_log_001/
+#           sync.arrow
+#           ego_state_se3.arrow
+#           box_detections_se3.arrow
+#           camera.pcam_f0.arrow
+#           camera.pcam_l0.arrow
+#           camera.pcam_r0.arrow
+#           lidar.lidar_merged.arrow
+#           custom.capture_metadata.arrow   # optional
+
+data: data/py123d
+log_id: my_log_001
+split: train
+
+# Camera / lidar names must match Arrow schema metadata (camera_name / lidar name).
+cameras:
+  - CAM_FRONT
+  - CAM_FRONT_LEFT
+  - CAM_FRONT_RIGHT
+lidars:
+  - LIDAR_TOP
+# neurad Lidars default; override to match your sensor.
+lidar_type: VELODYNE_VLP32C
+
+# Actors (requires box_detections_se3.arrow with an importable BoxDetectionLabel enum).
+load_cuboids: false
+include_deformable_actors: true
+allowed_rigid_classes:
+  - vehicle
+  - two_wheeler
+  - train
+  - bicycle
+  - motorcycle
+  - bus
+  - truck
+  - trailer
+allowed_deformable_classes:
+  - person
+  - human
+  - pedestrian
+
+# Merged multi-lidar clouds should keep this false.
+add_missing_points: false
+annotation_interval: 0.5
+
+# Rolling shutter (CLI overrides; not stored in the Arrow files).
+rolling_shutter_time: 0.03
+time_to_center_pixel: 0.0
+
+# Optional per-camera capture timestamps.
+use_capture_timestamps: true
+capture_metadata_modality: custom.capture_metadata
+
+# Equivalent train invocation:
+#
+#   TORCHDYNAMO_DISABLE=1 python nerfstudio/scripts/train.py splatad \
+#     --max-num-iterations 30001 \
+#     --vis tensorboard \
+#     py123d-data \
+#     --data data/py123d \
+#     --log-id my_log_001 \
+#     --split train \
+#     --cameras CAM_FRONT CAM_FRONT_LEFT CAM_FRONT_RIGHT \
+#     --lidars LIDAR_TOP \
+#     --lidar-type VELODYNE_VLP32C \
+#     --load-cuboids False \
+#     --rolling-shutter-time 0.03 \
+#     --time-to-center-pixel 0.0

--- a/docs/py123d-data.md
+++ b/docs/py123d-data.md
@@ -1,0 +1,163 @@
+# py123d data (`py123d-data`)
+
+Train NeuRAD / SplatAD on [py123d](https://github.com/kesai-labs/py123d) Apache Arrow
+driving logs. The dataparser reads a public log layout and takes camera / lidar names
+from config — no dataset-specific sensor defaults are baked in.
+
+| | |
+|---|---|
+| CLI subcommand | `py123d-data` |
+| Implementation | [`py123d_dataparser.py`](../nerfstudio/data/dataparsers/py123d_dataparser.py), [`py123d_utils.py`](../nerfstudio/data/dataparsers/py123d_utils.py) |
+| Extra dependency | [`py123d`](https://pypi.org/project/py123d/) (`pip install py123d`) |
+| Example config | [`docs/examples/py123d_example.yaml`](./examples/py123d_example.yaml) |
+
+## Expected log layout
+
+Point `--data` at a root that contains `logs/{split}/{log_id}/`:
+
+```text
+{data}/
+  logs/
+    {split}/
+      {log_id}/
+        sync.arrow
+        ego_state_se3.arrow
+        box_detections_se3.arrow          # optional; needed for --load-cuboids True
+        camera.{modality_key}.arrow       # one file per camera modality
+        lidar.{modality_key}.arrow        # e.g. lidar.lidar_merged.arrow
+        custom.capture_metadata.arrow     # optional per-camera capture times
+```
+
+Camera **names** passed on the CLI (e.g. `CAM_FRONT`) are resolved via Arrow schema
+metadata (`camera_name`) to modality keys (e.g. `camera.pcam_f0`). Lidar names (e.g.
+`LIDAR_TOP`) resolve the same way.
+
+### Supported cameras
+
+Only **pinhole** cameras (`PinholeCameraMetadata`) are supported today. Distortion is
+mapped to neurad's 6-element Brown model and undistorted by the image datamanager.
+
+### Optional capture-time sidecar
+
+When `--use-capture-timestamps True` (default), the dataparser loads
+`custom.capture_metadata.arrow` if present and uses per-camera
+`capture_timestamp_us` values. Missing sidecar or camera entries fall back to the
+camera-table anchor timestamp.
+
+Payload shape (MsgPack / JSON inside the custom modality):
+
+```json
+{
+  "schema_version": 1,
+  "cameras": {
+    "CAM_FRONT": { "capture_timestamp_us": 1234567890 }
+  }
+}
+```
+
+Override the modality key with `--capture-metadata-modality` if your exporter uses a
+different custom id (file name is `{modality}.arrow`).
+
+## Quickstart
+
+```bash
+pip install py123d
+
+# Inspect CLI options
+python nerfstudio/scripts/train.py splatad py123d-data --help
+
+# Smoke train (replace paths / sensor names with your export)
+TORCHDYNAMO_DISABLE=1 python nerfstudio/scripts/train.py splatad \
+  --max-num-iterations 100 \
+  --vis tensorboard \
+  py123d-data \
+  --data data/py123d \
+  --log-id my_log_001 \
+  --split train \
+  --cameras CAM_FRONT CAM_FRONT_LEFT CAM_FRONT_RIGHT \
+  --lidars LIDAR_TOP \
+  --lidar-type VELODYNE_VLP32C
+```
+
+Dataparser flags sit **flat** under the `py123d-data` subcommand (not under
+`--pipeline.datamanager.dataparser.*`).
+
+See [`docs/examples/py123d_example.yaml`](./examples/py123d_example.yaml) for a filled-in
+reference of common knobs.
+
+## Config knobs
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--data` | `data/py123d` | Root containing `logs/` |
+| `--log-id` | `""` | Log directory name under `logs/{split}/` |
+| `--split` | `train` | Split subdirectory |
+| `--cameras` | `()` | Required for camera training; names from Arrow `camera_name` |
+| `--lidars` | `()` | e.g. `LIDAR_TOP` |
+| `--lidar-type` | `VELODYNE_VLP32C` | Neurad `Lidars` default; override to match your sensor |
+| `--load-cuboids` | `False` | Load actor trajectories from `box_detections_se3.arrow` |
+| `--include-deformable-actors` | `True` | Include person / pedestrian-style classes |
+| `--allowed-rigid-classes` | vehicle, … | Prefix allowlist vs default-taxonomy label names |
+| `--allowed-deformable-classes` | person, human, pedestrian | Same, for deformable actors |
+| `--add-missing-points` | `False` | Keep off for merged multi-lidar clouds |
+| `--rolling-shutter-time` | `0.03` | Camera readout duration (seconds); `0.0` disables |
+| `--time-to-center-pixel` | `0.0` | Offset from capture timestamp to center-row time (seconds) |
+| `--horizontal-beam-divergence` | `0.003` | Same public default as ZOD / PandaSet |
+| `--vertical-beam-divergence` | `0.0015` | Same public default as ZOD / PandaSet |
+| `--use-capture-timestamps` | `True` | Prefer per-camera times from capture sidecar |
+| `--capture-metadata-modality` | `custom.capture_metadata` | Custom modality key for that sidecar |
+
+### Rolling shutter
+
+`--rolling-shutter-time` and `--time-to-center-pixel` are **training CLI overrides**.
+They are not read from the Arrow files. Leave `--time-to-center-pixel` at `0.0` when
+your capture timestamps already represent center-of-exposure (or when RS compensation
+is not needed). If your exporter stores **start-of-exposure** times, set
+`--time-to-center-pixel` to roughly half the sensor readout.
+
+### Dynamic actors
+
+With `--load-cuboids True`, boxes are grouped by `track_token`, filtered by the class
+prefix allowlists (matched against py123d's default label taxonomy via `to_default()`
+when available), transformed with the same WLH→LWH convention as nuScenes, and
+stationary tracks (xy std &lt; 0.5 m) are dropped.
+
+Box Arrow metadata must name an importable `BoxDetectionLabel` enum class. Prefer
+py123d's public `DefaultBoxDetectionLabel` in exports meant for this dataparser so
+no private label modules are required at train time.
+
+## Eval and render
+
+After training, point `--load-config` at the run's `config.yml`:
+
+```bash
+export CONFIG=outputs/<experiment>/splatad/<timestamp>/config.yml
+
+python nerfstudio/scripts/eval.py \
+  --load-config "$CONFIG" \
+  --output-path outputs/<experiment>/eval.json
+
+python nerfstudio/scripts/render.py dataset \
+  --load-config "$CONFIG" \
+  --output-path renders/<experiment> \
+  --pose-source val \
+  --rendered-output-names rgb gt-rgb depth
+```
+
+On GPUs with limited VRAM, dense lidar evaluation can OOM. In that case disable
+mid-train eval (`--steps-per-eval-image 999999`, etc.) and / or downsample lidar
+(`--pipeline.datamanager.downsample-factor 0.25`), then evaluate cameras separately.
+
+## Limitations / future work
+
+- Fisheye / wide-FOV cameras are not supported yet.
+- Lidar times use a linear sweep offset across the scan; true per-point timestamps
+  from the export are not consumed yet.
+- Multi-log training (list of `--log-id` values) is not implemented; train one log
+  at a time.
+
+## References
+
+- [py123d documentation](https://kesai-labs.github.io/py123d/)
+- [py123d paper](https://arxiv.org/html/2605.08084)
+- [NeuRAD](https://arxiv.org/abs/2311.15260) · [SplatAD](https://arxiv.org/abs/2411.16816)

--- a/docs/py123d-data.md
+++ b/docs/py123d-data.md
@@ -93,7 +93,7 @@ reference of common knobs.
 | `--log-id` | `""` | Log directory name under `logs/{split}/` |
 | `--split` | `train` | Split subdirectory |
 | `--cameras` | `()` | Required for camera training; names from Arrow `camera_name` |
-| `--lidars` | `()` | e.g. `LIDAR_TOP` |
+| `--lidars` | `()` | Exactly one name selecting an entry from `lidar.lidar_merged` (e.g. `LIDAR_TOP`) |
 | `--lidar-type` | `VELODYNE_VLP32C` | Neurad `Lidars` default; override to match your sensor |
 | `--load-cuboids` | `False` | Load actor trajectories from `box_detections_se3.arrow` |
 | `--include-deformable-actors` | `True` | Include person / pedestrian-style classes |

--- a/nerfstudio/configs/dataparser_configs.py
+++ b/nerfstudio/configs/dataparser_configs.py
@@ -39,6 +39,13 @@ dataparsers = {
 }
 
 try:
+    from nerfstudio.data.dataparsers.py123d_dataparser import Py123dDataParserConfig
+
+    dataparsers["py123d-data"] = Py123dDataParserConfig()
+except ImportError:
+    CONSOLE.print("py123d dataparser has missing dependencies; install py123d to enable py123d-data.")
+
+try:
     from nerfstudio.data.dataparsers.waymo_dataparser import WoDParserConfig
 
     dataparsers["wod-data"] = WoDParserConfig()

--- a/nerfstudio/data/dataparsers/py123d_dataparser.py
+++ b/nerfstudio/data/dataparsers/py123d_dataparser.py
@@ -1,0 +1,451 @@
+# Copyright 2026 the authors of NeuRAD and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data parser for py123d Arrow logs."""
+
+from __future__ import annotations
+
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Set, Tuple, Type
+
+import numpy as np
+import torch
+
+from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.cameras.lidars import Lidars, LidarType
+from nerfstudio.data.dataparsers.ad_dataparser import (
+    DUMMY_DISTANCE_VALUE,
+    OPENCV_TO_NERFSTUDIO,
+    ADDataParser,
+    ADDataParserConfig,
+)
+from nerfstudio.data.dataparsers.py123d_utils import (
+    DEFAULT_CAPTURE_METADATA_MODALITY,
+    WLH_TO_LWH,
+    bounding_box_se3_from_list,
+    box_label_to_category,
+    build_camera_name_to_modality_key,
+    find_lidar_entry,
+    get_box_detections_metadata,
+    get_camera_capture_timestamp_us,
+    get_lidar_merged_metadata,
+    get_pinhole_camera_metadata,
+    is_label_prefix_allowed,
+    iter_sync_rows,
+    lidar_ipc_to_numpy,
+    lidar_row_path,
+    load_capture_metadata_table,
+    modality_data_column,
+    modality_end_timestamp_column,
+    modality_pose_column,
+    modality_timestamp_column,
+    parse_lidar_row_path,
+    pinhole_distortion_to_neurad,
+    pose_list_to_matrix,
+    read_arrow_table,
+)
+
+# Reflectance is assumed normalized to [0, 1] in the decoded lidar IPC.
+MAX_REFLECTANCE_VALUE = 1.0
+
+
+@dataclass
+class Py123dDataParserConfig(ADDataParserConfig):
+    """py123d dataset config.
+
+    Reads Apache Arrow logs produced by exporters that follow the py123d log layout.
+    Camera names and lidar names are user-supplied values from the Arrow schema metadata.
+    """
+
+    _target: Type = field(default_factory=lambda: Py123dDataParser)
+    data: Path = Path("data/py123d")
+    """Root directory containing ``logs/{split}/{log_id}/``."""
+    log_id: str = ""
+    """Log directory name under ``{data}/logs/{split}/``."""
+    split: str = "train"
+    """Split subdirectory under ``{data}/logs/``."""
+    cameras: Tuple[str, ...] = ()
+    """Camera names from Arrow metadata (e.g. channel names stored in ``camera_name``)."""
+    lidars: Tuple[str, ...] = ()
+    """Lidar names from Arrow metadata (e.g. ``LIDAR_TOP``)."""
+    lidar_type: LidarType = LidarType.VELODYNE_VLP32C
+    """Lidar model used for rendering metadata.
+
+    Defaults to neurad's ``Lidars`` default (``VELODYNE_VLP32C``). Override to match
+    the sensor that produced your export.
+    """
+    load_cuboids: bool = False
+    """Whether to load dynamic actor trajectories from box detections."""
+    include_deformable_actors: bool = True
+    """Whether to include deformable classes (e.g. person) from the allowlist."""
+    allowed_rigid_classes: Tuple[str, ...] = (
+        "vehicle",
+        "two_wheeler",
+        "train",
+        "bicycle",
+        "motorcycle",
+        "bus",
+        "truck",
+        "trailer",
+    )
+    """Prefix allowlist for rigid actors. Matched against default-taxonomy label names."""
+    allowed_deformable_classes: Tuple[str, ...] = ("person", "human", "pedestrian")
+    """Prefix allowlist for deformable actors. Matched against default-taxonomy label names."""
+    add_missing_points: bool = False
+    """Disable missing-point synthesis until elevation maps are validated."""
+    annotation_interval: float = 0.5
+    """Approximate sync interval between samples (seconds)."""
+    rolling_shutter_time: float = 0.03
+    """Rolling shutter duration for cameras (seconds). Set to 0.0 to disable."""
+    # Same public defaults as ZOD / PandaSet dataparsers (radians at 1 m).
+    horizontal_beam_divergence: float = 3e-3
+    """Horizontal lidar beam divergence used for rendering metadata."""
+    vertical_beam_divergence: float = 1.5e-3
+    """Vertical lidar beam divergence used for rendering metadata."""
+    use_capture_timestamps: bool = True
+    """Use per-camera capture timestamps from an optional custom modality sidecar."""
+    capture_metadata_modality: str = DEFAULT_CAPTURE_METADATA_MODALITY
+    """Custom modality key for capture metadata (e.g. ``custom.capture_metadata``).
+
+    When ``use_capture_timestamps`` is True, the dataparser loads
+    ``{modality}.arrow`` if present and uses ``cameras[name].capture_timestamp_us``.
+    Missing sidecar / camera entries fall back to the camera-table anchor timestamp.
+    """
+
+    def __post_init__(self) -> None:
+        if self.log_id:
+            self.sequence = self.log_id
+        # Allow empty cameras/lidars at registration time (dataparser_configs.py /
+        # tyro defaults). Sensors must be supplied on the CLI before loading data.
+        if not (self.cameras or self.lidars or self.radars):
+            assert self.annotation_interval > 1e-6, "Child classes must specify the annotation interval"
+            assert self.dataset_start_fraction >= 0.0, "Dataset start fraction must be >= 0.0"
+            assert self.dataset_end_fraction <= 1.0, "Dataset end fraction must be <= 1.0"
+            assert self.dataset_start_fraction < self.dataset_end_fraction, "Dataset start must be < dataset end"
+            return
+        super().__post_init__()
+
+
+@dataclass
+class Py123dDataParser(ADDataParser):
+    """py123d dataset parser."""
+
+    config: Py123dDataParserConfig
+
+    def __post_init__(self) -> None:
+        self._log_dir: Path = Path()
+        self._sync_table = None
+        self._ego_table = None
+        self._camera_tables: Dict[str, object] = {}
+        self._camera_name_to_modality: Dict[str, str] = {}
+        self._camera_metadata: Dict[str, object] = {}
+        self._lidar_table = None
+        self._lidar_modality_key = "lidar.lidar_merged"
+        self._lidar_to_imu = np.eye(4)
+        self._box_table = None
+        self._box_label_class = None
+        self._capture_table = None
+        self._image_dir: Path = Path()
+        self._image_paths: Dict[Tuple[str, int], Path] = {}
+
+    @property
+    def actor_transform(self) -> torch.Tensor:
+        """Convert from neurad actor frame (x-right) to py123d/nuScenes (x-forward)."""
+        return torch.from_numpy(WLH_TO_LWH).float()[:3, :]
+
+    def _generate_dataparser_outputs(self, split="train"):
+        self._load_arrow_tables()
+        self._extract_camera_images()
+        return super()._generate_dataparser_outputs(split)
+
+    def _load_arrow_tables(self) -> None:
+        log_dir = self.config.data / "logs" / self.config.split / self.config.log_id
+        if not log_dir.exists():
+            raise FileNotFoundError(f"py123d log not found: {log_dir}")
+        self._log_dir = log_dir
+
+        self._sync_table = read_arrow_table(log_dir / "sync.arrow")
+        self._ego_table = read_arrow_table(log_dir / "ego_state_se3.arrow")
+        self._camera_name_to_modality = build_camera_name_to_modality_key(log_dir)
+
+        missing_cameras = [name for name in self.config.cameras if name not in self._camera_name_to_modality]
+        if missing_cameras:
+            available = sorted(self._camera_name_to_modality.keys())
+            raise KeyError(f"Configured cameras not found in log metadata: {missing_cameras}. Available: {available}")
+
+        for camera_name in self.config.cameras:
+            modality_key = self._camera_name_to_modality[camera_name]
+            arrow_path = log_dir / f"{modality_key}.arrow"
+            self._camera_tables[modality_key] = read_arrow_table(arrow_path)
+            self._camera_metadata[camera_name] = get_pinhole_camera_metadata(arrow_path)
+
+        if self.config.lidars:
+            lidar_path = log_dir / f"{self._lidar_modality_key}.arrow"
+            self._lidar_table = read_arrow_table(lidar_path)
+            merged_metadata = get_lidar_merged_metadata(lidar_path)
+            _, lidar_entry = find_lidar_entry(merged_metadata, self.config.lidars[0])
+            self._lidar_to_imu = pose_list_to_matrix(lidar_entry.lidar_to_imu_se3.array)
+
+        if self.config.load_cuboids:
+            box_path = log_dir / "box_detections_se3.arrow"
+            if not box_path.exists():
+                raise FileNotFoundError(f"load_cuboids=True but box file not found: {box_path}")
+            try:
+                box_metadata = get_box_detections_metadata(box_path)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Could not resolve box detection label class from {box_path}. "
+                    "The label enum referenced in Arrow schema metadata must be importable "
+                    "(e.g. DefaultBoxDetectionLabel, or a dataset-specific enum on PYTHONPATH)."
+                ) from exc
+            self._box_label_class = box_metadata.box_detection_label_class
+            self._box_table = read_arrow_table(box_path)
+
+        if self.config.use_capture_timestamps:
+            self._capture_table = load_capture_metadata_table(
+                log_dir, self.config.capture_metadata_modality
+            )
+
+        self._image_dir = Path(tempfile.mkdtemp(prefix="py123d_images_"))
+
+    def _extract_camera_images(self) -> None:
+        for camera_name in self.config.cameras:
+            modality_key = self._camera_name_to_modality[camera_name]
+            table = self._camera_tables[modality_key]
+            data_column = modality_data_column(table)
+            for row_idx in range(table.num_rows):
+                image_bytes = data_column[row_idx].as_py()
+                if not image_bytes:
+                    continue
+                image_path = self._image_dir / f"{modality_key.replace('.', '_')}_{row_idx:05d}.jpg"
+                image_path.write_bytes(image_bytes)
+                self._image_paths[(modality_key, row_idx)] = image_path
+
+    def _get_cameras(self) -> Tuple[Cameras, List[Path]]:
+        filenames: List[Path] = []
+        times: List[float] = []
+        intrinsics: List[np.ndarray] = []
+        distortions: List[np.ndarray] = []
+        poses: List[np.ndarray] = []
+        idxs: List[int] = []
+        heights: List[int] = []
+        widths: List[int] = []
+
+        for cam_idx, camera_name in enumerate(self.config.cameras):
+            modality_key = self._camera_name_to_modality[camera_name]
+            metadata = self._camera_metadata[camera_name]
+            table = self._camera_tables[modality_key]
+            pose_column = modality_pose_column(table)
+            timestamp_column = modality_timestamp_column(table)
+            assert pose_column is not None
+
+            for sync_row in iter_sync_rows(self._sync_table):
+                row_idx = int(self._sync_table.column(modality_key)[sync_row].as_py())
+                pose = pose_list_to_matrix(pose_column[row_idx].as_py())
+                pose[:3, :3] = pose[:3, :3] @ OPENCV_TO_NERFSTUDIO
+
+                anchor_ts_us = timestamp_column[row_idx].as_py()
+                capture_ts_us = None
+                if self.config.use_capture_timestamps:
+                    capture_ts_us = get_camera_capture_timestamp_us(
+                        self._capture_table,
+                        self._sync_table,
+                        self.config.capture_metadata_modality,
+                        sync_row,
+                        camera_name,
+                    )
+                times.append((capture_ts_us if capture_ts_us is not None else anchor_ts_us) / 1e6)
+
+                filenames.append(self._image_paths[(modality_key, row_idx)])
+                intrinsics.append(
+                    np.array(
+                        [
+                            [metadata.intrinsics.fx, 0.0, metadata.intrinsics.cx],
+                            [0.0, metadata.intrinsics.fy, metadata.intrinsics.cy],
+                            [0.0, 0.0, 1.0],
+                        ],
+                        dtype=np.float32,
+                    )
+                )
+                distortions.append(pinhole_distortion_to_neurad(metadata.distortion))
+                poses.append(pose)
+                idxs.append(cam_idx)
+                heights.append(metadata.height)
+                widths.append(metadata.width)
+
+        intrinsics_tensor = torch.tensor(np.array(intrinsics), dtype=torch.float32)
+        distortion_tensor = torch.tensor(np.array(distortions), dtype=torch.float32)
+        poses_tensor = torch.tensor(np.array(poses), dtype=torch.float32)
+        times_tensor = torch.tensor(times, dtype=torch.float64)
+        idxs_tensor = torch.tensor(idxs, dtype=torch.int32).unsqueeze(-1)
+
+        cameras = Cameras(
+            fx=intrinsics_tensor[:, 0, 0],
+            fy=intrinsics_tensor[:, 1, 1],
+            cx=intrinsics_tensor[:, 0, 2],
+            cy=intrinsics_tensor[:, 1, 2],
+            height=torch.tensor(heights, dtype=torch.int32),
+            width=torch.tensor(widths, dtype=torch.int32),
+            distortion_params=distortion_tensor,
+            camera_to_worlds=poses_tensor[:, :3, :4],
+            camera_type=CameraType.PERSPECTIVE,
+            times=times_tensor,
+            metadata={"sensor_idxs": idxs_tensor},
+        )
+        return cameras, filenames
+
+    def _get_lidars(self) -> Tuple[Lidars, List[Path]]:
+        filenames: List[Path] = []
+        poses: List[np.ndarray] = []
+        times: List[float] = []
+        idxs: List[int] = []
+
+        ego_pose_column = None
+        for name in self._ego_table.column_names:
+            if name.endswith(".imu_se3"):
+                ego_pose_column = self._ego_table.column(name)
+                break
+        assert ego_pose_column is not None
+
+        timestamp_column = modality_timestamp_column(self._lidar_table)
+        end_timestamp_column = modality_end_timestamp_column(self._lidar_table)
+
+        ego_column_name = "ego_state_se3"
+        for lidar_idx, _lidar_name in enumerate(self.config.lidars):
+            for sync_row in iter_sync_rows(self._sync_table):
+                row_idx = int(self._sync_table.column(self._lidar_modality_key)[sync_row].as_py())
+                ego_row_idx = int(self._sync_table.column(ego_column_name)[sync_row].as_py())
+                ego_pose = pose_list_to_matrix(ego_pose_column[ego_row_idx].as_py())
+                lidar_pose = ego_pose @ self._lidar_to_imu
+
+                filenames.append(lidar_row_path(row_idx))
+                poses.append(lidar_pose)
+                times.append(timestamp_column[row_idx].as_py() / 1e6)
+                idxs.append(lidar_idx)
+
+        poses_tensor = torch.tensor(np.array(poses), dtype=torch.float32)
+        times_tensor = torch.tensor(times, dtype=torch.float64)
+        idxs_tensor = torch.tensor(idxs, dtype=torch.int32).unsqueeze(-1)
+
+        lidars = Lidars(
+            lidar_to_worlds=poses_tensor[:, :3, :4],
+            lidar_type=self.config.lidar_type,
+            assume_ego_compensated=False,
+            times=times_tensor,
+            metadata={"sensor_idxs": idxs_tensor},
+            horizontal_beam_divergence=self.config.horizontal_beam_divergence,
+            vertical_beam_divergence=self.config.vertical_beam_divergence,
+            valid_lidar_distance_threshold=DUMMY_DISTANCE_VALUE / 2,
+        )
+        return lidars, filenames
+
+    def _read_lidars(self, lidars: Lidars, filepaths: List[Path]) -> List[torch.Tensor]:
+        point_clouds: List[torch.Tensor] = []
+        data_column = modality_data_column(self._lidar_table)
+        timestamp_column = modality_timestamp_column(self._lidar_table)
+        end_timestamp_column = modality_end_timestamp_column(self._lidar_table)
+
+        for filepath, lidar_time in zip(filepaths, lidars.times.squeeze(-1)):
+            row_idx = parse_lidar_row_path(filepath)
+            start_us = timestamp_column[row_idx].as_py()
+            end_us = end_timestamp_column[row_idx].as_py() if end_timestamp_column is not None else start_us
+            sweep_duration_s = max((end_us - start_us) / 1e6, 0.0)
+
+            # lidar_ipc_to_numpy already returns relative sweep time offsets in
+            # [-sweep_duration, 0]; do not subtract absolute lidar timestamps.
+            pc = torch.from_numpy(lidar_ipc_to_numpy(data_column[row_idx].as_py(), sweep_duration_s))
+            point_clouds.append(pc)
+
+        return point_clouds
+
+    def _get_actor_trajectories(self) -> List[Dict]:
+        """Load dynamic actor trajectories from ``box_detections_se3.arrow``.
+
+        Boxes are grouped by ``track_token``, filtered by the configured class-prefix
+        allowlist (matched against py123d default-taxonomy names via ``to_default()``),
+        and converted to neurad's actor frame with ``WLH_TO_LWH``. Stationary tracks
+        (xy std < 0.5 m) are dropped, matching the nuScenes parser.
+        """
+        assert self._box_table is not None and self._box_label_class is not None
+
+        timestamp_col = self._box_table.column("box_detections_se3.timestamp_us")
+        boxes_col = self._box_table.column("box_detections_se3.bounding_box_se3")
+        tokens_col = self._box_table.column("box_detections_se3.track_token")
+        labels_col = self._box_table.column("box_detections_se3.label")
+
+        trajs: Dict[str, List[Dict]] = defaultdict(list)
+        for row_idx in range(self._box_table.num_rows):
+            timestamp_s = timestamp_col[row_idx].as_py() / 1e6
+            boxes = boxes_col[row_idx].as_py()
+            tokens = tokens_col[row_idx].as_py()
+            labels = labels_col[row_idx].as_py()
+            for box_values, track_token, label_value in zip(boxes, tokens, labels):
+                if not track_token:
+                    continue
+                box = bounding_box_se3_from_list(box_values)
+                pose = box.center_se3.transformation_matrix @ WLH_TO_LWH
+                # neurad dims are documented as wlh; py123d stores length/width/height.
+                wlh = np.array([box.width, box.length, box.height], dtype=np.float32)
+                category = box_label_to_category(self._box_label_class, int(label_value))
+                trajs[track_token].append(
+                    {
+                        "pose": pose.astype(np.float32),
+                        "wlh": wlh,
+                        "label": category,
+                        "time": timestamp_s,
+                    }
+                )
+
+        return self._traj_dict_to_list(trajs)
+
+    def _traj_dict_to_list(self, traj: Dict[str, List[Dict]]) -> List[Dict]:
+        """Convert per-track observation lists into neurad trajectory dicts."""
+        allowed: Set[str] = set(self.config.allowed_rigid_classes)
+        if self.config.include_deformable_actors:
+            allowed.update(self.config.allowed_deformable_classes)
+
+        traj_out: List[Dict] = []
+        for track_token, traj_list in traj.items():
+            if len(traj_list) < 2:
+                continue
+            label = traj_list[0]["label"]
+            if not is_label_prefix_allowed(label, allowed):
+                continue
+
+            poses = torch.from_numpy(np.stack([t["pose"] for t in traj_list]).astype(np.float32))
+            times = torch.from_numpy(np.array([t["time"] for t in traj_list], dtype=np.float64))
+            dims = torch.from_numpy(np.stack([t["wlh"] for t in traj_list]).astype(np.float32))
+            dims = dims.max(0).values
+
+            dynamic = bool((poses[:, :2, 3].std(dim=0) > 0.50).any())
+            if not dynamic:
+                continue
+
+            deformable = is_label_prefix_allowed(label, set(self.config.allowed_deformable_classes))
+            traj_out.append(
+                {
+                    "uuid": track_token,
+                    "label": label,
+                    "poses": poses,
+                    "timestamps": times,
+                    "dims": dims,
+                    "stationary": False,
+                    "symmetric": not deformable,
+                    "deformable": deformable,
+                }
+            )
+        return traj_out

--- a/nerfstudio/data/dataparsers/py123d_dataparser.py
+++ b/nerfstudio/data/dataparsers/py123d_dataparser.py
@@ -81,7 +81,11 @@ class Py123dDataParserConfig(ADDataParserConfig):
     cameras: Tuple[str, ...] = ()
     """Camera names from Arrow metadata (e.g. channel names stored in ``camera_name``)."""
     lidars: Tuple[str, ...] = ()
-    """Lidar names from Arrow metadata (e.g. ``LIDAR_TOP``)."""
+    """Lidar names from Arrow metadata (e.g. ``LIDAR_TOP``).
+
+    Currently only a single name is supported: it selects one entry from the
+    merged ``lidar.lidar_merged`` modality. Passing multiple names raises.
+    """
     lidar_type: LidarType = LidarType.VELODYNE_VLP32C
     """Lidar model used for rendering metadata.
 
@@ -159,6 +163,7 @@ class Py123dDataParser(ADDataParser):
         self._box_table = None
         self._box_label_class = None
         self._capture_table = None
+        self._image_tmpdir = None
         self._image_dir: Path = Path()
         self._image_paths: Dict[Tuple[str, int], Path] = {}
 
@@ -194,6 +199,11 @@ class Py123dDataParser(ADDataParser):
             self._camera_metadata[camera_name] = get_pinhole_camera_metadata(arrow_path)
 
         if self.config.lidars:
+            if len(self.config.lidars) != 1:
+                raise ValueError(
+                    "py123d-data currently supports exactly one lidar name selecting an entry "
+                    f"from lidar.lidar_merged; got {list(self.config.lidars)}"
+                )
             lidar_path = log_dir / f"{self._lidar_modality_key}.arrow"
             self._lidar_table = read_arrow_table(lidar_path)
             merged_metadata = get_lidar_merged_metadata(lidar_path)
@@ -220,17 +230,28 @@ class Py123dDataParser(ADDataParser):
                 log_dir, self.config.capture_metadata_modality
             )
 
-        self._image_dir = Path(tempfile.mkdtemp(prefix="py123d_images_"))
+        # Keep TemporaryDirectory alive for the parser lifetime so images remain
+        # readable, then clean up automatically when the parser is discarded.
+        self._image_tmpdir = tempfile.TemporaryDirectory(prefix="py123d_images_")
+        self._image_dir = Path(self._image_tmpdir.name)
 
     def _extract_camera_images(self) -> None:
+        """Extract image payloads for rows referenced by ``sync.arrow``."""
         for camera_name in self.config.cameras:
             modality_key = self._camera_name_to_modality[camera_name]
             table = self._camera_tables[modality_key]
             data_column = modality_data_column(table)
-            for row_idx in range(table.num_rows):
+            needed_rows = {
+                int(self._sync_table.column(modality_key)[sync_row].as_py())
+                for sync_row in iter_sync_rows(self._sync_table)
+            }
+            for row_idx in sorted(needed_rows):
                 image_bytes = data_column[row_idx].as_py()
                 if not image_bytes:
-                    continue
+                    raise ValueError(
+                        f"Missing image payload for camera '{camera_name}' "
+                        f"(modality '{modality_key}', row {row_idx})"
+                    )
                 image_path = self._image_dir / f"{modality_key.replace('.', '_')}_{row_idx:05d}.jpg"
                 image_path.write_bytes(image_bytes)
                 self._image_paths[(modality_key, row_idx)] = image_path

--- a/nerfstudio/data/dataparsers/py123d_utils.py
+++ b/nerfstudio/data/dataparsers/py123d_utils.py
@@ -115,12 +115,14 @@ def find_lidar_entry(
 
 
 def decode_lidar_ipc(data: bytes) -> np.ndarray:
-    """Decode embedded lidar IPC bytes to ``[x, y, z, intensity, channel, ids]``."""
+    """Decode embedded lidar IPC bytes to ``[x, y, z, intensity, channel]``."""
     table = pa.ipc.open_stream(data).read_all()
-    xyz = table.select(["x", "y", "z"]).to_pandas().to_numpy(dtype=np.float32)
+    x = table.column("x").to_numpy().astype(np.float32, copy=False)
+    y = table.column("y").to_numpy().astype(np.float32, copy=False)
+    z = table.column("z").to_numpy().astype(np.float32, copy=False)
     intensity = table.column("intensity").to_numpy().astype(np.float32) / 255.0
     channel = table.column("channel").to_numpy().astype(np.float32)
-    return np.stack([xyz[:, 0], xyz[:, 1], xyz[:, 2], intensity, channel], axis=1)
+    return np.stack([x, y, z, intensity, channel], axis=1)
 
 
 def lidar_ipc_to_numpy(

--- a/nerfstudio/data/dataparsers/py123d_utils.py
+++ b/nerfstudio/data/dataparsers/py123d_utils.py
@@ -1,0 +1,268 @@
+# Copyright 2026 the authors of NeuRAD and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for reading py123d Arrow logs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
+
+import msgpack
+import numpy as np
+import pyarrow as pa
+from py123d.api.utils.arrow_metadata_utils import get_metadata_from_arrow_schema, parse_log_directory_metadata
+from py123d.datatypes.detections.box_detection_label import BoxDetectionLabel
+from py123d.datatypes.detections.box_detections_metadata import BoxDetectionsSE3Metadata
+from py123d.datatypes.sensors.base_camera import BaseCameraMetadata, camera_metadata_from_dict
+from py123d.datatypes.sensors.lidar import LidarMergedMetadata, LidarMetadata
+from py123d.datatypes.sensors.pinhole_camera import PinholeCameraMetadata, PinholeDistortion
+from py123d.geometry.bounding_box import BoundingBoxSE3
+from py123d.geometry.pose import PoseSE3
+
+LIDAR_ROW_PATH_PREFIX = "__py123d_lidar_row__"
+DEFAULT_CAPTURE_METADATA_MODALITY = "custom.capture_metadata"
+
+# py123d / nuScenes actor frame is x-forward, y-left, z-up. Neurad uses x-right,
+# y-forward, z-up, so rotate actor poses by 90 degrees about z (same as nuScenes).
+WLH_TO_LWH = np.array(
+    [
+        [0.0, 1.0, 0.0, 0.0],
+        [-1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ],
+    dtype=np.float64,
+)
+
+
+def read_arrow_table(path: Path) -> pa.Table:
+    """Read all record batches from a py123d Arrow IPC file."""
+    reader = pa.ipc.open_file(path)
+    return reader.read_all()
+
+
+def pose_list_to_matrix(pose_values: Sequence[float]) -> np.ndarray:
+    """Convert a py123d ``[x, y, z, qw, qx, qy, qz]`` pose to a 4x4 matrix."""
+    return PoseSE3.from_list(list(pose_values)).transformation_matrix
+
+
+def pinhole_distortion_to_neurad(
+    distortion: Optional[Union[PinholeDistortion, Sequence[float]]],
+) -> np.ndarray:
+    """Map py123d pinhole distortion to neurad's 6-element Brown model."""
+    if distortion is None:
+        return np.zeros(6, dtype=np.float32)
+    if isinstance(distortion, PinholeDistortion):
+        coeffs = [distortion.k1, distortion.k2, distortion.p1, distortion.p2, distortion.k3]
+    else:
+        coeffs = list(distortion)
+        while len(coeffs) < 5:
+            coeffs.append(0.0)
+    k1, k2, p1, p2, k3 = coeffs[:5]
+    return np.array([k1, k2, k3, 0.0, p1, p2], dtype=np.float32)
+
+
+def build_camera_name_to_modality_key(log_dir: Path) -> Dict[str, str]:
+    """Map ``camera_name`` values (e.g. ``CAM_FRONT``) to modality keys (e.g. ``camera.pcam_f0``)."""
+    log_metadata = parse_log_directory_metadata(log_dir)
+    mapping: Dict[str, str] = {}
+    for modality_key, metadata in log_metadata.modality_metadatas.items():
+        if not isinstance(metadata, BaseCameraMetadata):
+            continue
+        mapping[metadata.camera_name] = modality_key
+    return mapping
+
+
+def get_pinhole_camera_metadata(arrow_path: Path) -> PinholeCameraMetadata:
+    """Load and validate pinhole camera metadata from an Arrow file schema."""
+    schema = pa.ipc.open_file(arrow_path).schema
+    metadata = camera_metadata_from_dict(msgpack.unpackb(schema.metadata[b"metadata"], raw=False))
+    if not isinstance(metadata, PinholeCameraMetadata):
+        raise TypeError(
+            f"Only pinhole cameras are supported; got {type(metadata).__name__} for '{arrow_path.name}'"
+        )
+    return metadata
+
+
+def get_lidar_merged_metadata(arrow_path: Path) -> LidarMergedMetadata:
+    """Load merged lidar metadata from an Arrow file schema."""
+    schema = pa.ipc.open_file(arrow_path).schema
+    return get_metadata_from_arrow_schema(schema, LidarMergedMetadata)
+
+
+def find_lidar_entry(
+    merged_metadata: LidarMergedMetadata, lidar_name: str
+) -> Tuple[str, LidarMetadata]:
+    """Return the metadata entry for a configured lidar name."""
+    for lidar_id, entry in merged_metadata.lidar_metadatas.items():
+        if entry.lidar_name == lidar_name:
+            return str(lidar_id), entry
+    available = [entry.lidar_name for entry in merged_metadata.lidar_metadatas.values()]
+    raise KeyError(f"Lidar '{lidar_name}' not found in merged metadata. Available: {available}")
+
+
+def decode_lidar_ipc(data: bytes) -> np.ndarray:
+    """Decode embedded lidar IPC bytes to ``[x, y, z, intensity, channel, ids]``."""
+    table = pa.ipc.open_stream(data).read_all()
+    xyz = table.select(["x", "y", "z"]).to_pandas().to_numpy(dtype=np.float32)
+    intensity = table.column("intensity").to_numpy().astype(np.float32) / 255.0
+    channel = table.column("channel").to_numpy().astype(np.float32)
+    return np.stack([xyz[:, 0], xyz[:, 1], xyz[:, 2], intensity, channel], axis=1)
+
+
+def lidar_ipc_to_numpy(
+    data: bytes,
+    sweep_duration_s: float,
+) -> np.ndarray:
+    """Decode lidar IPC bytes to neurad array format ``[x, y, z, intensity, time, channel]``."""
+    points = decode_lidar_ipc(data)
+    num_points = points.shape[0]
+    if num_points == 0:
+        return np.zeros((0, 6), dtype=np.float32)
+    time_offsets = np.linspace(-sweep_duration_s, 0.0, num_points, dtype=np.float32)
+    return np.concatenate([points[:, :4], time_offsets[:, None], points[:, 4:5]], axis=1).astype(np.float32)
+
+
+def modality_data_column(table: pa.Table) -> pa.ChunkedArray:
+    """Return the payload column for a py123d modality table."""
+    for name in table.column_names:
+        if name.endswith(".data"):
+            return table.column(name)
+    raise KeyError(f"No '.data' column found in table with columns: {table.column_names}")
+
+
+def modality_pose_column(table: pa.Table) -> Optional[pa.ChunkedArray]:
+    """Return the global pose column for a camera modality table, if present."""
+    for name in table.column_names:
+        if name.endswith(".camera_to_global_se3"):
+            return table.column(name)
+    return None
+
+
+def modality_timestamp_column(table: pa.Table) -> pa.ChunkedArray:
+    """Return the timestamp column for a py123d modality table."""
+    for name in table.column_names:
+        if name.endswith(".timestamp_us"):
+            return table.column(name)
+    raise KeyError(f"No '.timestamp_us' column found in table with columns: {table.column_names}")
+
+
+def modality_end_timestamp_column(table: pa.Table) -> Optional[pa.ChunkedArray]:
+    """Return the sweep end timestamp column for a lidar modality table, if present."""
+    for name in table.column_names:
+        if name.endswith(".end_timestamp_us"):
+            return table.column(name)
+    return None
+
+
+def lidar_row_path(row_idx: int) -> Path:
+    """Create a synthetic path token that encodes a lidar row index."""
+    return Path(f"{LIDAR_ROW_PATH_PREFIX}{row_idx}")
+
+
+def parse_lidar_row_path(path: Path) -> int:
+    """Parse a synthetic lidar row path created by :func:`lidar_row_path`."""
+    return int(path.name.removeprefix(LIDAR_ROW_PATH_PREFIX))
+
+
+def iter_sync_rows(sync_table: pa.Table) -> Iterable[int]:
+    """Iterate row indices present in ``sync.arrow``."""
+    return range(sync_table.num_rows)
+
+
+def get_box_detections_metadata(arrow_path: Path) -> BoxDetectionsSE3Metadata:
+    """Load box-detection schema metadata, including the label enum class."""
+    schema = pa.ipc.open_file(arrow_path).schema
+    return get_metadata_from_arrow_schema(schema, BoxDetectionsSE3Metadata)
+
+
+def bounding_box_se3_from_list(values: Sequence[float]) -> BoundingBoxSE3:
+    """Convert a py123d 10-float box array to ``BoundingBoxSE3``."""
+    return BoundingBoxSE3.from_array(np.asarray(values, dtype=np.float64))
+
+
+def box_label_to_category(label_class: Type[BoxDetectionLabel], label_value: int) -> str:
+    """Map a stored label enum int to a lowercase default-taxonomy category string.
+
+    Dataset-specific enums are converted via ``to_default()`` so the public dataparser
+    can filter with generic prefixes like ``vehicle`` / ``person``.
+    """
+    return label_class(label_value).to_default().name.lower()
+
+
+def is_label_prefix_allowed(label: str, allowed_prefixes: Set[str]) -> bool:
+    """Return True if ``label`` equals or starts with any allowed prefix.
+
+    Examples:
+        ``vehicle.emergency`` matches ``vehicle``; ``two_wheeler`` matches ``two_wheeler``.
+    """
+    label = label.lower()
+    for prefix in allowed_prefixes:
+        prefix = prefix.lower()
+        if label == prefix or label.startswith(prefix + ".") or label.startswith(prefix + "_"):
+            return True
+    return False
+
+
+def decode_capture_metadata_payload(data: Any) -> Dict[str, Any]:
+    """Decode a capture-metadata row payload from msgpack bytes, JSON bytes/str, or dict."""
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, (bytes, bytearray)):
+        try:
+            return msgpack.unpackb(data, raw=False)
+        except Exception:
+            return json.loads(data.decode("utf-8"))
+    if isinstance(data, str):
+        return json.loads(data)
+    raise TypeError(f"Unsupported capture metadata payload type: {type(data)}")
+
+
+def load_capture_metadata_table(log_dir: Path, modality_key: str) -> Optional[pa.Table]:
+    """Load an optional capture-metadata custom modality table, or ``None`` if absent."""
+    if not modality_key:
+        return None
+    path = log_dir / f"{modality_key}.arrow"
+    if not path.exists():
+        return None
+    return read_arrow_table(path)
+
+
+def get_camera_capture_timestamp_us(
+    capture_table: Optional[pa.Table],
+    sync_table: pa.Table,
+    modality_key: str,
+    sync_row: int,
+    camera_name: str,
+) -> Optional[int]:
+    """Return per-camera ``capture_timestamp_us`` from the sidecar, or ``None`` to fall back.
+
+    Looks up the capture-metadata row via ``sync_table[modality_key][sync_row]``, decodes
+    the payload, and reads ``payload["cameras"][camera_name]["capture_timestamp_us"]``.
+    """
+    if capture_table is None or modality_key not in sync_table.column_names:
+        return None
+    capture_row = sync_table.column(modality_key)[sync_row].as_py()
+    if capture_row is None:
+        return None
+    data_column = modality_data_column(capture_table)
+    payload = decode_capture_metadata_payload(data_column[int(capture_row)].as_py())
+    cameras = payload.get("cameras") or {}
+    entry = cameras.get(camera_name)
+    if not entry:
+        return None
+    capture_ts = entry.get("capture_timestamp_us")
+    return int(capture_ts) if capture_ts is not None else None

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -1,0 +1,284 @@
+# Copyright 2026 the authors of NeuRAD and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthetic py123d Arrow log for dataparser unit / smoke tests."""
+
+from __future__ import annotations
+
+import io
+import uuid
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import msgpack
+import numpy as np
+import pyarrow as pa
+import pytest
+from PIL import Image
+from py123d.api.utils.arrow_metadata_utils import parse_log_directory_metadata
+from py123d.datatypes.custom.custom_modality import CustomModalityMetadata
+from py123d.datatypes.detections.box_detection_label import DefaultBoxDetectionLabel
+from py123d.datatypes.detections.box_detections_metadata import BoxDetectionsSE3Metadata
+from py123d.datatypes.metadata.log_metadata import LogMetadata
+from py123d.datatypes.sensors.base_camera import CameraID
+from py123d.datatypes.sensors.lidar import LidarID, LidarMergedMetadata, LidarMetadata
+from py123d.datatypes.sensors.pinhole_camera import PinholeCameraMetadata, PinholeDistortion, PinholeIntrinsics
+from py123d.datatypes.vehicle_state.ego_state_metadata import EgoStateSE3Metadata
+from py123d.geometry.pose import PoseSE3
+
+MINI_LOG_ID = "mini_log_001"
+MINI_SPLIT = "train"
+NUM_SAMPLES = 3
+IMAGE_WIDTH = 64
+IMAGE_HEIGHT = 48
+CAMERAS: Tuple[Tuple[str, CameraID], ...] = (
+    ("CAM_FRONT", CameraID.PCAM_F0),
+    ("CAM_FRONT_LEFT", CameraID.PCAM_L0),
+)
+LIDAR_NAME = "LIDAR_TOP"
+IDENTITY_POSE = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+
+
+def _pose(x: float, y: float = 0.0, z: float = 0.0) -> List[float]:
+    return [x, y, z, 1.0, 0.0, 0.0, 0.0]
+
+
+def _write_arrow(path: Path, table: pa.Table, metadata_dict: Dict) -> None:
+    schema = table.schema.with_metadata({"metadata": msgpack.packb(metadata_dict, use_bin_type=True)})
+    table = table.replace_schema_metadata(schema.metadata)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with pa.OSFile(str(path), "wb") as sink:
+        with pa.ipc.new_file(sink, schema) as writer:
+            writer.write_table(table)
+
+
+def _jpeg_bytes(seed: int) -> bytes:
+    rng = np.random.default_rng(seed)
+    array = rng.integers(0, 255, size=(IMAGE_HEIGHT, IMAGE_WIDTH, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(array, mode="RGB").save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+def _lidar_ipc_bytes(num_points: int = 32) -> bytes:
+    xyz = np.stack(
+        [
+            np.linspace(1.0, 10.0, num_points, dtype=np.float32),
+            np.zeros(num_points, dtype=np.float32),
+            np.ones(num_points, dtype=np.float32),
+        ],
+        axis=1,
+    )
+    intensity = np.full(num_points, 128, dtype=np.uint8)
+    channel = np.zeros(num_points, dtype=np.uint16)
+    ids = np.arange(num_points, dtype=np.int32)
+    table = pa.table(
+        {
+            "x": xyz[:, 0],
+            "y": xyz[:, 1],
+            "z": xyz[:, 2],
+            "intensity": intensity,
+            "channel": channel,
+            "ids": ids,
+        }
+    )
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
+def build_mini_py123d_log(data_root: Path, *, num_samples: int = NUM_SAMPLES) -> Path:
+    """Write a tiny synthetic py123d log under ``data_root/logs/{split}/{log_id}/``.
+
+    Returns the log directory path. Clears py123d's log-metadata LRU cache so the
+    new files are visible to subsequent ``parse_log_directory_metadata`` calls.
+    """
+    log_dir = data_root / "logs" / MINI_SPLIT / MINI_LOG_ID
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    base_ts = 1_700_000_000_000_000
+    timestamps = [base_ts + i * 500_000 for i in range(num_samples)]
+
+    camera_meta: Dict[str, PinholeCameraMetadata] = {}
+    for camera_name, camera_id in CAMERAS:
+        camera_meta[camera_name] = PinholeCameraMetadata(
+            camera_name=camera_name,
+            camera_id=camera_id,
+            intrinsics=PinholeIntrinsics(fx=50.0, fy=50.0, cx=IMAGE_WIDTH / 2, cy=IMAGE_HEIGHT / 2, skew=0.0),
+            distortion=PinholeDistortion(k1=-0.1, k2=0.05, p1=0.0, p2=0.0, k3=0.0),
+            width=IMAGE_WIDTH,
+            height=IMAGE_HEIGHT,
+            camera_to_imu_se3=PoseSE3.from_list([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+        )
+
+    # Cameras
+    for camera_name, metadata in camera_meta.items():
+        modality = metadata.modality_key
+        rows_ts = []
+        rows_data = []
+        rows_pose = []
+        for i, ts in enumerate(timestamps):
+            rows_ts.append(ts)
+            rows_data.append(_jpeg_bytes(hash((camera_name, i)) & 0xFFFF))
+            # Camera pose in world: translate with ego.
+            rows_pose.append(_pose(float(i)))
+        table = pa.table(
+            {
+                f"{modality}.timestamp_us": pa.array(rows_ts, type=pa.int64()),
+                f"{modality}.data": pa.array(rows_data, type=pa.binary()),
+                f"{modality}.camera_to_global_se3": pa.array(rows_pose, type=pa.list_(pa.float64(), 7)),
+            }
+        )
+        _write_arrow(log_dir / f"{modality}.arrow", table, metadata.to_dict())
+
+    # Ego
+    ego_meta = EgoStateSE3Metadata(
+        vehicle_name="test_vehicle",
+        width=1.8,
+        length=4.5,
+        height=1.5,
+        wheel_base=2.7,
+        center_to_imu_se3=PoseSE3.from_list([1.2, 0.0, 0.7, 1.0, 0.0, 0.0, 0.0]),
+        rear_axle_to_imu_se3=PoseSE3.from_list(IDENTITY_POSE),
+    )
+    ego_table = pa.table(
+        {
+            "ego_state_se3.timestamp_us": pa.array(timestamps, type=pa.int64()),
+            "ego_state_se3.imu_se3": pa.array([_pose(float(i)) for i in range(num_samples)], type=pa.list_(pa.float64(), 7)),
+            "ego_state_se3.dynamic_state_se3": pa.array(
+                [[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] for _ in range(num_samples)],
+                type=pa.list_(pa.float64(), 9),
+            ),
+        }
+    )
+    _write_arrow(log_dir / "ego_state_se3.arrow", ego_table, ego_meta.to_dict())
+
+    # Lidar (merged modality file; channel name is user-facing LIDAR_TOP)
+    lidar_meta = LidarMergedMetadata(
+        {
+            LidarID.LIDAR_MERGED: LidarMetadata(
+                lidar_name=LIDAR_NAME,
+                lidar_id=LidarID.LIDAR_MERGED,
+                lidar_to_imu_se3=PoseSE3.from_list([0.0, 0.0, 1.5, 1.0, 0.0, 0.0, 0.0]),
+            )
+        }
+    )
+    lidar_table = pa.table(
+        {
+            "lidar.lidar_merged.timestamp_us": pa.array(timestamps, type=pa.int64()),
+            "lidar.lidar_merged.end_timestamp_us": pa.array(
+                [ts + 50_000 for ts in timestamps], type=pa.int64()
+            ),
+            "lidar.lidar_merged.data": pa.array(
+                [_lidar_ipc_bytes(24 + i) for i in range(num_samples)], type=pa.binary()
+            ),
+        }
+    )
+    _write_arrow(log_dir / "lidar.lidar_merged.arrow", lidar_table, lidar_meta.to_dict())
+
+    # Capture sidecar: per-camera offsets from the shared anchor.
+    capture_meta = CustomModalityMetadata(
+        modality_id="capture_metadata",
+        metadata={"schema_version": 1, "description": "synthetic capture timestamps"},
+    )
+    capture_payloads = []
+    for i, ts in enumerate(timestamps):
+        payload = {
+            "schema_version": 1,
+            "cameras": {
+                "CAM_FRONT": {"capture_timestamp_us": ts + 10_000},
+                "CAM_FRONT_LEFT": {"capture_timestamp_us": ts + 25_000},
+            },
+        }
+        capture_payloads.append(msgpack.packb(payload, use_bin_type=True))
+    capture_table = pa.table(
+        {
+            "custom.capture_metadata.timestamp_us": pa.array(timestamps, type=pa.int64()),
+            "custom.capture_metadata.data": pa.array(capture_payloads, type=pa.binary()),
+        }
+    )
+    _write_arrow(log_dir / "custom.capture_metadata.arrow", capture_table, capture_meta.to_dict())
+
+    # Boxes: one moving vehicle track (xy moves > 0.5 m std across samples).
+    box_meta = BoxDetectionsSE3Metadata(DefaultBoxDetectionLabel)
+    boxes: List[List[List[float]]] = []
+    tokens: List[List[str]] = []
+    labels: List[List[int]] = []
+    velocities: List[List[List[float]]] = []
+    num_pts: List[List[int]] = []
+    for i in range(num_samples):
+        # length, width, height after xyz + quat
+        box = [float(i) * 2.0, 5.0, 0.5, 1.0, 0.0, 0.0, 0.0, 4.0, 2.0, 1.5]
+        boxes.append([box])
+        tokens.append(["track_vehicle_0"])
+        labels.append([int(DefaultBoxDetectionLabel.VEHICLE)])
+        velocities.append([[2.0, 0.0, 0.0]])
+        num_pts.append([10])
+    box_table = pa.table(
+        {
+            "box_detections_se3.timestamp_us": pa.array(timestamps, type=pa.int64()),
+            "box_detections_se3.bounding_box_se3": pa.array(
+                boxes, type=pa.list_(pa.list_(pa.float64(), 10))
+            ),
+            "box_detections_se3.track_token": pa.array(tokens, type=pa.list_(pa.string())),
+            "box_detections_se3.label": pa.array(labels, type=pa.list_(pa.uint16())),
+            "box_detections_se3.velocity_3d": pa.array(
+                velocities, type=pa.list_(pa.list_(pa.float64(), 3))
+            ),
+            "box_detections_se3.num_lidar_points": pa.array(num_pts, type=pa.list_(pa.int32())),
+        }
+    )
+    _write_arrow(log_dir / "box_detections_se3.arrow", box_table, box_meta.to_dict())
+
+    # Sync
+    sync_cols: Dict[str, Sequence] = {
+        "sync.uuid": [uuid.uuid4().bytes for _ in range(num_samples)],
+        "sync.timestamp_us": timestamps,
+        "box_detections_se3": list(range(num_samples)),
+        "ego_state_se3": list(range(num_samples)),
+        "lidar.lidar_merged": list(range(num_samples)),
+        "custom.capture_metadata": list(range(num_samples)),
+    }
+    for metadata in camera_meta.values():
+        sync_cols[metadata.modality_key] = list(range(num_samples))
+
+    arrays = {
+        "sync.uuid": pa.array(sync_cols["sync.uuid"], type=pa.uuid()),
+        "sync.timestamp_us": pa.array(sync_cols["sync.timestamp_us"], type=pa.int64()),
+    }
+    for key, values in sync_cols.items():
+        if key in arrays:
+            continue
+        arrays[key] = pa.array(values, type=pa.int64())
+    sync_table = pa.table(arrays)
+    log_meta = LogMetadata(
+        dataset="example",
+        split=MINI_SPLIT,
+        log_name=MINI_LOG_ID,
+        location="test",
+        version="0.0.1",
+        map_metadata=None,
+    )
+    _write_arrow(log_dir / "sync.arrow", sync_table, log_meta.to_dict())
+
+    parse_log_directory_metadata.cache_clear()
+    return log_dir
+
+
+@pytest.fixture(scope="module")
+def mini_log(tmp_path_factory) -> Path:
+    """Module-scoped synthetic py123d log directory."""
+    root = tmp_path_factory.mktemp("py123d_data")
+    return build_mini_py123d_log(root)

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -21,10 +21,14 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Sequence, Tuple
 
+import pytest
+
+# py123d is an optional dependency; skip this test package when it is not installed.
+pytest.importorskip("py123d")
+
 import msgpack
 import numpy as np
 import pyarrow as pa
-import pytest
 from PIL import Image
 from py123d.api.utils.arrow_metadata_utils import parse_log_directory_metadata
 from py123d.datatypes.custom.custom_modality import CustomModalityMetadata

--- a/tests/data/test_py123d_dataparser.py
+++ b/tests/data/test_py123d_dataparser.py
@@ -1,0 +1,199 @@
+# Copyright 2026 the authors of NeuRAD and contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from nerfstudio.data.dataparsers.py123d_utils import (
+    DEFAULT_CAPTURE_METADATA_MODALITY,
+    WLH_TO_LWH,
+    bounding_box_se3_from_list,
+    build_camera_name_to_modality_key,
+    decode_capture_metadata_payload,
+    get_camera_capture_timestamp_us,
+    get_pinhole_camera_metadata,
+    is_label_prefix_allowed,
+    lidar_ipc_to_numpy,
+    load_capture_metadata_table,
+    pinhole_distortion_to_neurad,
+    pose_list_to_matrix,
+    read_arrow_table,
+)
+
+
+def test_pinhole_distortion_to_neurad() -> None:
+    coeffs = pinhole_distortion_to_neurad([-0.4, 0.22, 0.0007, 0.0004, -0.096])
+    assert coeffs.tolist() == pytest.approx([-0.4, 0.22, -0.096, 0.0, 0.0007, 0.0004])
+
+
+def test_pose_list_to_matrix_is_valid_rigid_transform() -> None:
+    matrix = pose_list_to_matrix([1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0])
+    assert matrix.shape == (4, 4)
+    assert matrix[3, 3] == 1.0
+    rotation = matrix[:3, :3]
+    assert np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-5)
+
+
+def test_is_label_prefix_allowed() -> None:
+    allowed = {"vehicle", "person", "two_wheeler"}
+    assert is_label_prefix_allowed("vehicle", allowed)
+    assert is_label_prefix_allowed("vehicle.emergency", allowed)
+    assert is_label_prefix_allowed("person", allowed)
+    assert is_label_prefix_allowed("two_wheeler", allowed)
+    assert not is_label_prefix_allowed("animal", allowed)
+    assert not is_label_prefix_allowed("other", allowed)
+
+
+def test_bounding_box_se3_from_list_and_wlh_rotation() -> None:
+    box = bounding_box_se3_from_list([1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 4.0, 2.0, 1.5])
+    assert box.length == pytest.approx(4.0)
+    assert box.width == pytest.approx(2.0)
+    assert box.height == pytest.approx(1.5)
+    pose = box.center_se3.transformation_matrix @ WLH_TO_LWH
+    assert pose.shape == (4, 4)
+    assert np.allclose(pose[:3, 3], [1.0, 2.0, 3.0])
+
+
+def test_decode_capture_metadata_payload_dict_passthrough() -> None:
+    payload = {"cameras": {"CAM_FRONT": {"capture_timestamp_us": 123}}}
+    assert decode_capture_metadata_payload(payload) is payload
+
+
+def test_mini_capture_metadata_sidecar(mini_log: Path) -> None:
+    capture = load_capture_metadata_table(mini_log, DEFAULT_CAPTURE_METADATA_MODALITY)
+    assert capture is not None
+    sync = read_arrow_table(mini_log / "sync.arrow")
+    ts = get_camera_capture_timestamp_us(
+        capture, sync, DEFAULT_CAPTURE_METADATA_MODALITY, sync_row=0, camera_name="CAM_FRONT"
+    )
+    assert ts is not None
+    assert (
+        get_camera_capture_timestamp_us(
+            capture, sync, DEFAULT_CAPTURE_METADATA_MODALITY, sync_row=0, camera_name="MISSING"
+        )
+        is None
+    )
+    assert load_capture_metadata_table(mini_log, "custom.does_not_exist") is None
+
+
+def test_mini_log_camera_metadata_and_lidar_decode(mini_log: Path) -> None:
+    mapping = build_camera_name_to_modality_key(mini_log)
+    assert "CAM_FRONT" in mapping
+
+    metadata = get_pinhole_camera_metadata(mini_log / f"{mapping['CAM_FRONT']}.arrow")
+    assert metadata.camera_name == "CAM_FRONT"
+    assert metadata.intrinsics.fx > 0
+
+    lidar_table = read_arrow_table(mini_log / "lidar.lidar_merged.arrow")
+    data = lidar_table.column(2)[0].as_py()
+    points = lidar_ipc_to_numpy(data, sweep_duration_s=0.05)
+    assert points.shape[1] == 6
+    assert points.shape[0] > 0
+
+
+def test_py123d_dataparser_smoke(mini_log: Path) -> None:
+    torch = pytest.importorskip("torch")
+
+    from nerfstudio.cameras.lidars import LidarType
+    from nerfstudio.data.dataparsers.py123d_dataparser import Py123dDataParser, Py123dDataParserConfig
+
+    config = Py123dDataParserConfig(
+        data=mini_log.parents[2],
+        log_id="mini_log_001",
+        split="train",
+        cameras=("CAM_FRONT", "CAM_FRONT_LEFT"),
+        lidars=("LIDAR_TOP",),
+        lidar_type=LidarType.VELODYNE_VLP32C,
+        train_split_fraction=1.0,
+    )
+    parser = Py123dDataParser(config)
+    outputs = parser.get_dataparser_outputs("train")
+
+    assert len(outputs.image_filenames) == 3 * len(config.cameras)
+    assert outputs.cameras.shape[0] == len(outputs.image_filenames)
+    assert outputs.metadata["lidars"].shape[0] == 3
+    assert len(outputs.metadata["point_clouds"]) == 3
+    assert outputs.metadata["point_clouds"][0].shape[1] == 6
+    assert outputs.cameras.distortion_params is not None
+    assert torch.all(outputs.cameras.distortion_params[:, 3] == 0)
+
+
+def test_py123d_actor_trajectories(mini_log: Path) -> None:
+    torch = pytest.importorskip("torch")
+
+    from nerfstudio.cameras.lidars import LidarType
+    from nerfstudio.data.dataparsers.py123d_dataparser import Py123dDataParser, Py123dDataParserConfig
+
+    config = Py123dDataParserConfig(
+        data=mini_log.parents[2],
+        log_id="mini_log_001",
+        split="train",
+        cameras=("CAM_FRONT",),
+        lidars=("LIDAR_TOP",),
+        lidar_type=LidarType.VELODYNE_VLP32C,
+        load_cuboids=True,
+        train_split_fraction=1.0,
+    )
+    parser = Py123dDataParser(config)
+    outputs = parser.get_dataparser_outputs("train")
+
+    trajectories = outputs.metadata["trajectories"]
+    assert len(trajectories) > 0
+    traj = trajectories[0]
+    assert traj["poses"].ndim == 3 and traj["poses"].shape[-2:] == (4, 4)
+    assert traj["timestamps"].ndim == 1
+    assert traj["dims"].shape == (3,)
+    assert traj["label"] == "vehicle"
+    assert traj["stationary"] is False
+    assert traj["deformable"] is False
+    assert torch.is_floating_point(traj["poses"])
+
+
+def test_py123d_per_camera_capture_timestamps(mini_log: Path) -> None:
+    torch = pytest.importorskip("torch")
+
+    from nerfstudio.cameras.lidars import LidarType
+    from nerfstudio.data.dataparsers.py123d_dataparser import Py123dDataParser, Py123dDataParserConfig
+
+    cameras = ("CAM_FRONT", "CAM_FRONT_LEFT")
+    common = dict(
+        data=mini_log.parents[2],
+        log_id="mini_log_001",
+        split="train",
+        cameras=cameras,
+        lidars=("LIDAR_TOP",),
+        lidar_type=LidarType.VELODYNE_VLP32C,
+        train_split_fraction=1.0,
+    )
+
+    with_capture = Py123dDataParser(
+        Py123dDataParserConfig(**common, use_capture_timestamps=True)
+    ).get_dataparser_outputs("train")
+    without_capture = Py123dDataParser(
+        Py123dDataParserConfig(**common, use_capture_timestamps=False)
+    ).get_dataparser_outputs("train")
+
+    n = 3
+    capture_f = with_capture.cameras.times[:n].squeeze(-1)
+    capture_l = with_capture.cameras.times[n : 2 * n].squeeze(-1)
+    anchor_f = without_capture.cameras.times[:n].squeeze(-1)
+    anchor_l = without_capture.cameras.times[n : 2 * n].squeeze(-1)
+
+    assert not torch.allclose(capture_f, capture_l)
+    assert torch.allclose(anchor_f, anchor_l)
+    assert not torch.allclose(capture_f, anchor_f)
+    delta_ms = (capture_f - anchor_f).abs() * 1e3
+    assert float(delta_ms.mean()) == pytest.approx(10.0, abs=0.1)

--- a/tests/data/test_py123d_dataparser.py
+++ b/tests/data/test_py123d_dataparser.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+# py123d is an optional dependency; skip these tests when it is not installed.
 pytest.importorskip("py123d", reason="py123d is an optional dependency for these tests")
 
 from nerfstudio.data.dataparsers.py123d_utils import (
@@ -131,6 +132,25 @@ def test_py123d_dataparser_smoke(mini_log: Path) -> None:
     assert outputs.metadata["point_clouds"][0].shape[1] == 6
     assert outputs.cameras.distortion_params is not None
     assert torch.all(outputs.cameras.distortion_params[:, 3] == 0)
+
+
+def test_py123d_rejects_multiple_lidars(mini_log: Path) -> None:
+    pytest.importorskip("torch")
+
+    from nerfstudio.cameras.lidars import LidarType
+    from nerfstudio.data.dataparsers.py123d_dataparser import Py123dDataParser, Py123dDataParserConfig
+
+    config = Py123dDataParserConfig(
+        data=mini_log.parents[2],
+        log_id="mini_log_001",
+        split="train",
+        cameras=("CAM_FRONT",),
+        lidars=("LIDAR_TOP", "LIDAR_REAR"),
+        lidar_type=LidarType.VELODYNE_VLP32C,
+        train_split_fraction=1.0,
+    )
+    with pytest.raises(ValueError, match="exactly one lidar name"):
+        Py123dDataParser(config).get_dataparser_outputs("train")
 
 
 def test_py123d_actor_trajectories(mini_log: Path) -> None:

--- a/tests/data/test_py123d_dataparser.py
+++ b/tests/data/test_py123d_dataparser.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytest.importorskip("py123d", reason="py123d is an optional dependency for these tests")
+
 from nerfstudio.data.dataparsers.py123d_utils import (
     DEFAULT_CAPTURE_METADATA_MODALITY,
     WLH_TO_LWH,


### PR DESCRIPTION
Hi! Thanks for NeuRAD / neurad-studio.

This PR adds a `py123d-data` dataparser for [py123d](https://github.com/kesai-labs/py123d) Apache Arrow driving logs, following the existing AD dataparser pattern (similar intent to the [Waymo dataparser PR](https://github.com/georghess/neurad-studio/pull/33)).

Includes:
- Pinhole camera loading with distortion → neurad undistortion
- Lidar IPC decode and linear sweep-time offsets
- Optional actor trajectories (`--load-cuboids`) with class-prefix allowlists
- Optional per-camera capture timestamps from a `custom.capture_metadata` sidecar
- CLI registration as `py123d-data`
- Docs + example config: [docs/py123d-data.md](https://github.com/cjdellaporta/neurad-studio-fork/blob/feat/py123d-dataparser/docs/py123d-data.md), [docs/examples/py123d_example.yaml](https://github.com/cjdellaporta/neurad-studio-fork/blob/feat/py123d-dataparser/docs/examples/py123d_example.yaml)
- Synthetic unit tests under `tests/data/`

Camera and lidar names are supplied via config. Default `lidar_type` matches neurad's `Lidars` default (`VELODYNE_VLP32C`). Extra dependency: `pip install py123d`.

References: [py123d docs](https://kesai-labs.github.io/py123d/), [py123d paper](https://arxiv.org/html/2605.08084)